### PR TITLE
Add serialization declarations for ServerCustom data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ circle-ci = { repository = "steamroller-airmash/airmash-protocol-rs" }
 maintenance = { status = "experimental" }
 
 [features]
-default = ["specs"]
+default = ["custom_data"]
+custom_data = ["serde", "serde_json"]
 
 [dependencies]
 lazy_static = "1.0"
@@ -24,6 +25,10 @@ derive_more = "0.12"
 
 [dependencies.specs]
 version = "0.12"
+optional = true
+
+[dependencies.serde_json]
+version = "1.0"
 optional = true
 
 [dependencies.serde]

--- a/src/custom/btr.rs
+++ b/src/custom/btr.rs
@@ -1,0 +1,33 @@
+use enums::FlagCode;
+use std::time::Duration;
+
+use super::utils::*;
+
+/// Serde serialization declaration for [`ServerCustom`][0]
+/// data for BTR.
+///
+/// This struct will serialize from/deserialize to the JSON
+/// representation used in the `data` field of `ServerCustom`.
+///
+/// # Serialization Notes
+/// - If the server sends an invalid flag code it will be
+///   deserialized as [`FlagCode::UnitedNations`][1]
+/// - `duration` is only encoded at the resolution of seconds.
+///
+/// [0]: ../packets/client/struct.ServerCustom.html
+/// [1]: ../enum.FlagCode.html#variant.UnitedNations
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BTRData {
+	#[serde(rename = "p")]
+	pub player: String,
+	#[serde(rename = "b")]
+	pub bounty: u32,
+	#[serde(rename = "f")]
+	#[serde(with = "flag_code")]
+	pub flag: FlagCode,
+	#[serde(rename = "k")]
+	pub kills: u32,
+	#[serde(rename = "t")]
+	#[serde(with = "duration")]
+	pub duration: Duration,
+}

--- a/src/custom/ctf.rs
+++ b/src/custom/ctf.rs
@@ -1,0 +1,25 @@
+use std::time::Duration;
+use Team;
+
+use super::utils::*;
+
+/// Serde serialization declaration for [`ServerCustom`][0]
+/// data for CTF.
+///
+/// This struct will serialize from/deserialize to the JSON
+/// representation used in the `data` field of `ServerCustom`.
+///
+/// # Serialization Notes
+/// - `duration` is only encoded at the resolution of seconds.
+///
+/// [0]: ../packets/client/struct.ServerCustom.html
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct CTFData {
+	#[serde(rename = "w")]
+	pub winner: Team,
+	#[serde(rename = "b")]
+	pub bounty: u32,
+	#[serde(rename = "t")]
+	#[serde(with = "duration")]
+	pub duration: Duration,
+}

--- a/src/custom/mod.rs
+++ b/src/custom/mod.rs
@@ -1,0 +1,7 @@
+//! Data serialization declarations for `ServerCustom`
+//! packets.
+//!
+
+mod btr;
+mod ctf;
+mod utils;

--- a/src/custom/utils.rs
+++ b/src/custom/utils.rs
@@ -1,0 +1,40 @@
+pub(crate) mod flag_code {
+	use enums::FlagCode;
+	use serde::*;
+	use std::convert::TryInto;
+
+	pub fn serialize<S>(flag: &FlagCode, s: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		s.serialize_u32(*flag as u32)
+	}
+
+	pub fn deserialize<'de, D>(de: D) -> Result<FlagCode, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		Ok(u8::deserialize(de)?
+			.try_into()
+			.unwrap_or(FlagCode::UnitedNations))
+	}
+}
+
+pub(crate) mod duration {
+	use serde::*;
+	use std::time::Duration;
+
+	pub fn serialize<S>(duration: &Duration, s: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		s.serialize_u64(duration.as_secs())
+	}
+
+	pub fn deserialize<'de, D>(de: D) -> Result<Duration, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		Ok(Duration::from_secs(u64::deserialize(de)?))
+	}
+}

--- a/src/enums/command_reply_type.rs
+++ b/src/enums/command_reply_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 use std::convert::From;

--- a/src/enums/error_type.rs
+++ b/src/enums/error_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum!{

--- a/src/enums/firewall_status.rs
+++ b/src/enums/firewall_status.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/firewall_update_type.rs
+++ b/src/enums/firewall_update_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/flag_code.rs
+++ b/src/enums/flag_code.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 use std::convert::TryFrom;
 use std::str::FromStr;

--- a/src/enums/flag_update_type.rs
+++ b/src/enums/flag_update_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/game_type.rs
+++ b/src/enums/game_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/key_code.rs
+++ b/src/enums/key_code.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/leave_horizon_type.rs
+++ b/src/enums/leave_horizon_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/mob_type.rs
+++ b/src/enums/mob_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/plane_type.rs
+++ b/src/enums/plane_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/player_level_type.rs
+++ b/src/enums/player_level_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/player_status.rs
+++ b/src/enums/player_status.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/powerup_type.rs
+++ b/src/enums/powerup_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/server_custom_type.rs
+++ b/src/enums/server_custom_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {
@@ -8,6 +9,8 @@ impl_try_from_enum! {
 	#[cfg_attr(feature = "specs", derive(Component))]
 	#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 	pub enum ServerCustomType {
+		/// TODO: Determine if this name is accurate
+		BTRWin = 1,
 		/// TODO: Determine if this name is accurate
 		CTFWin = 2,
 	}

--- a/src/enums/server_message_type.rs
+++ b/src/enums/server_message_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/enums/upgrade_type.rs
+++ b/src/enums/upgrade_type.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "specs")]
 use specs::DenseVecStorage;
 
 impl_try_from_enum! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ mod types;
 mod client_packet;
 mod server_packet;
 
+#[cfg(feature = "serde")]
+pub mod custom;
 pub mod error;
 
 pub use self::client_packet::*;


### PR DESCRIPTION
This provides (feature-gated) structs that serialize to the `ServerCustom` data. It also incorporates the stuff from [this issue on the main server repo](https://github.com/steamroller-airmash/airmash-server/issues/5) for BTR data.