### PR TITLE
Convert vector types to use mint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ serde = [ "serde-feature-hack", "serde_json", "bstr/serde1" ]
 default = [ ]
 
 [dependencies]
-bstr = "0.2.16"
-smallvec = "1.6.1"
-nalgebra = "0.31.0"
+bstr       = { version = "0.2.16", default-features = false, features=["std"] }
+smallvec   = "1.6.1"
 num-traits = "0.2"
 derivative = "2.2"
+mint       = "0.5"
 
 [dependencies.serde_json]
 version = "1.0"

--- a/src/packets/debug.rs
+++ b/src/packets/debug.rs
@@ -3,12 +3,12 @@
 
 use std::fmt::{Debug, Formatter, Result};
 
-use nalgebra::Vector2;
+use crate::types::Vector2;
 
-pub(crate) fn fmt_vector(v: &Vector2<f32>, f: &mut Formatter) -> Result {
+pub(crate) fn fmt_vector(v: &Vector2, f: &mut Formatter) -> Result {
   write!(f, "({}, {})", v.x, v.y)
 }
 
-pub(crate) fn fmt_opt_vector(v: &Option<Vector2<f32>>, f: &mut Formatter) -> Result {
+pub(crate) fn fmt_opt_vector(v: &Option<Vector2>, f: &mut Formatter) -> Result {
   v.map(|v| (v.x, v.y)).fmt(f)
 }

--- a/src/packets/serde.rs
+++ b/src/packets/serde.rs
@@ -1,6 +1,6 @@
-use crate::Vector2;
+use crate::{types::VectorExt, Vector2};
 
-type FVec2 = Vector2<f32>;
+type FVec2 = Vector2;
 
 #[derive(Serialize, Deserialize)]
 #[serde(remote = "FVec2")]
@@ -28,6 +28,7 @@ impl From<VecRemote> for FVec2 {
 
 pub(crate) mod opt_vec {
   use super::FVec2;
+  use crate::types::VectorExt;
   use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
   #[derive(Serialize, Deserialize)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,7 +4,7 @@ mod server_key_state;
 mod upgrades;
 
 pub use self::units::*;
-pub use nalgebra::Vector2;
+pub(crate) type Vector2 = mint::Vector2<f32>;
 
 pub use self::server_key_state::ServerKeyState;
 pub use self::upgrades::Upgrades;
@@ -15,3 +15,13 @@ pub type Team = u16;
 pub type Flag = u16;
 pub type Level = u8;
 pub type Score = u32;
+
+pub(crate) trait VectorExt {
+  fn new(x: f32, y: f32) -> Self;
+}
+
+impl VectorExt for Vector2 {
+  fn new(x: f32, y: f32) -> Self {
+    Self { x, y }
+  }
+}

--- a/src/types/units.rs
+++ b/src/types/units.rs
@@ -58,8 +58,8 @@ pub type AccelScalar = f32; // self::base::Accel<BaseType>;
 pub type RotationRate = f32;
 
 /// A 2D vector of [`Distance`]s.
-pub type Position = Vector2<Distance>;
+pub type Position = Vector2;
 /// A 2D vector of [`Speed`]s.
-pub type Velocity = Vector2<Speed>;
+pub type Velocity = Vector2;
 /// A 2D vector of [`AccelScalar`]s.
-pub type Accel = Vector2<AccelScalar>;
+pub type Accel = Vector2;

--- a/src/v5/protocol.rs
+++ b/src/v5/protocol.rs
@@ -1,4 +1,5 @@
 use super::Result;
+use crate::types::VectorExt;
 use crate::v5::{Error, ErrorExt as _, ErrorKind};
 use crate::Vector2;
 use bstr::{BStr, BString, ByteSlice};
@@ -152,36 +153,33 @@ impl<'ser> AirmashSerializerV5<'ser> {
     self.serialize_bytes(data.as_bytes())
   }
 
-  pub fn serialize_accel(&mut self, v: Vector2<f32>) -> Result {
-    ACCEL_SPEC.ser(self, v[0])?;
-    ACCEL_SPEC.ser(self, v[1])
+  pub fn serialize_accel(&mut self, v: Vector2) -> Result {
+    ACCEL_SPEC.ser(self, v.x)?;
+    ACCEL_SPEC.ser(self, v.y)
   }
-  pub fn serialize_low_res_pos(&mut self, pos: Option<Vector2<f32>>) -> Result {
-    let x = pos
-      .map(|v| ((v[0] / 128.0) as i32 + 128) as u8)
-      .unwrap_or(0);
-    let y = pos
-      .map(|v| ((v[1] / 128.0) as i32 + 128) as u8)
-      .unwrap_or(0);
+  pub fn serialize_low_res_pos(&mut self, pos: Option<Vector2>) -> Result {
+    let x = pos.map(|v| ((v.x / 128.0) as i32 + 128) as u8).unwrap_or(0);
+    let y = pos.map(|v| ((v.y / 128.0) as i32 + 128) as u8).unwrap_or(0);
 
     x.serialize(self)?;
     y.serialize(self)
   }
-  pub fn serialize_pos_f32(&mut self, pos: Vector2<f32>) -> Result {
-    self.serialize_f32(pos[0])?;
-    self.serialize_f32(pos[1])
+  pub fn serialize_pos_f32(&mut self, pos: Vector2) -> Result {
+    self.serialize_f32(pos.x)?;
+    self.serialize_f32(pos.y)
   }
-  pub fn serialize_pos(&mut self, pos: Vector2<f32>) -> Result {
-    self.serialize_coordx(pos[0])?;
-    self.serialize_coordy(pos[1])
+  pub fn serialize_pos(&mut self, pos: Vector2) -> Result {
+    self.serialize_coordx(pos.x)?;
+    self.serialize_coordy(pos.y)
   }
-  pub fn serialize_pos24(&mut self, pos: Vector2<f32>) -> Result {
-    self.serialize_coord24(pos[0])?;
-    self.serialize_coord24(pos[1])
+
+  pub fn serialize_pos24(&mut self, pos: Vector2) -> Result {
+    self.serialize_coord24(pos.x)?;
+    self.serialize_coord24(pos.y)
   }
-  pub fn serialize_vel(&mut self, pos: Vector2<f32>) -> Result {
-    self.serialize_speed(pos[0])?;
-    self.serialize_speed(pos[1])
+  pub fn serialize_vel(&mut self, pos: Vector2) -> Result {
+    self.serialize_speed(pos.x)?;
+    self.serialize_speed(pos.y)
   }
 
   pub fn serialize_coord24(&mut self, v: f32) -> Result {
@@ -344,10 +342,10 @@ impl<'de> AirmashDeserializerV5<'de> {
     Ok(self.deserialize_bytes(len)?.into())
   }
 
-  pub fn deserialize_accel(&mut self) -> Result<Vector2<f32>> {
+  pub fn deserialize_accel(&mut self) -> Result<Vector2> {
     Ok(Vector2::new(ACCEL_SPEC.de(self)?, ACCEL_SPEC.de(self)?))
   }
-  pub fn deserialize_low_res_pos(&mut self) -> Result<Option<Vector2<f32>>> {
+  pub fn deserialize_low_res_pos(&mut self) -> Result<Option<Vector2>> {
     let (x, y): (u8, u8) = self.deserialize()?;
 
     if x == 0 && y == 0 {
@@ -359,25 +357,25 @@ impl<'de> AirmashDeserializerV5<'de> {
       ((y as i32 - 128) * 128) as f32,
     )))
   }
-  pub fn deserialize_pos_f32(&mut self) -> Result<Vector2<f32>> {
+  pub fn deserialize_pos_f32(&mut self) -> Result<Vector2> {
     Ok(Vector2::new(
       self.deserialize_f32()?,
       self.deserialize_f32()?,
     ))
   }
-  pub fn deserialize_pos(&mut self) -> Result<Vector2<f32>> {
+  pub fn deserialize_pos(&mut self) -> Result<Vector2> {
     Ok(Vector2::new(
       self.deserialize_coordx()?,
       self.deserialize_coordy()?,
     ))
   }
-  pub fn deserialize_pos24(&mut self) -> Result<Vector2<f32>> {
+  pub fn deserialize_pos24(&mut self) -> Result<Vector2> {
     Ok(Vector2::new(
       self.deserialize_coord24()?,
       self.deserialize_coord24()?,
     ))
   }
-  pub fn deserialize_vel(&mut self) -> Result<Vector2<f32>> {
+  pub fn deserialize_vel(&mut self) -> Result<Vector2> {
     Ok(Vector2::new(
       self.deserialize_speed()?,
       self.deserialize_speed()?,

--- a/src/v5/tests.rs
+++ b/src/v5/tests.rs
@@ -1,6 +1,7 @@
 use super::serialize;
 use crate::{
   server::PlayerUpdate,
+  types::VectorExt,
   v5::{AirmashDeserializerV5, AirmashSerializerV5},
   ServerKeyState, ServerPacket, Upgrades, Vector2,
 };


### PR DESCRIPTION
This allows for downstream crates to use whichever vector library they like since all of them support conversions to/from mint. Furthermore, nalgebra is really heavy to compile and by using mint we can cut the dependencies here in half.