### PR TITLE
Revert "Remove dependency on serde-feature-hack in favour of just using serde"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 circle-ci = { repository = "steamroller-airmash/airmash-protocol-rs" }
 
 [features]
-serde = [ "serde1", "serde_json", "bstr/serde1" ]
+serde = [ "serde-feature-hack", "serde_json", "bstr/serde1" ]
 default = [ ]
 
 [dependencies]
@@ -21,10 +21,14 @@ bstr       = { version = "0.2.16", default-features = false, features=["std"] }
 smallvec   = "1.6.1"
 num-traits = "0.2"
 mint       = "0.5"
-serde1     = { version = "1.0", features = ["derive"], optional = true, package = "serde" }
 
 [dependencies.serde_json]
 version = "1.0"
+optional = true
+
+[dependencies.serde-feature-hack]
+version = "0.2"
+features = ["derive"]
 optional = true
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 
 #[cfg(feature = "serde")]
 #[cfg_attr(feature = "serde", macro_use)]
-extern crate serde1 as serde;
+extern crate serde;
 #[cfg(feature = "specs")]
 extern crate specs;
 


### PR DESCRIPTION
Reverts steamroller-airmash/airmash-protocol-rs#11

Turns out this breaks serde and it wasn't caught by CI.