### PR TITLE
Add support for ab-protocol `LOGIN` packet variant

### DIFF
--- a/src/packets/server.rs
+++ b/src/packets/server.rs
@@ -1,5 +1,7 @@
 //! Packets that the server sends to the client.
 
+use std::ops::{Deref, DerefMut};
+
 use bstr::BString;
 
 use crate::enums::*;
@@ -269,6 +271,23 @@ pub struct Login {
   pub ty: GameType,
   pub room: BString,
   pub players: Vec<LoginPlayer>,
+}
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct LoginBot {
+  pub id: Player,
+}
+
+/// Upgraded Login packet introduced in https://github.com/wight-airmash/ab-protocol
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+
+pub struct Login2 {
+  pub login: Login,
+  #[cfg_attr(feature = "serde", serde(rename = "serverConfiguration"))]
+  pub config: BString,
+  pub bots: Vec<LoginBot>,
 }
 
 /// A missile despawned with an explosion. This is used when a missile collides
@@ -662,4 +681,21 @@ pub struct ScoreDetailedFFAEntry {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ScoreDetailedFFA {
   pub scores: Vec<ScoreDetailedFFAEntry>,
+}
+
+//===================================================================
+// Extra trait implementations
+
+impl Deref for Login2 {
+  type Target = Login;
+
+  fn deref(&self) -> &Self::Target {
+    &self.login
+  }
+}
+
+impl DerefMut for Login2 {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.login
+  }
 }

--- a/src/server_packet.rs
+++ b/src/server_packet.rs
@@ -17,6 +17,7 @@ use crate::server::*;
 #[non_exhaustive]
 pub enum ServerPacket {
   Login(Login),
+  Login2(Login2),
   Backup,
   Ping(Ping),
   PingResult(PingResult),

--- a/src/v5/protocol.rs
+++ b/src/v5/protocol.rs
@@ -225,6 +225,13 @@ impl<'de> AirmashDeserializerV5<'de> {
     self.data
   }
 
+  pub fn checkpoint(&self) -> &'de [u8] {
+    self.remainder()
+  }
+  pub fn restore(&mut self, checkpoint: &'de [u8]) {
+    self.data = checkpoint;
+  }
+
   pub fn deserialize<T: DeserializeV5<'de>>(&mut self) -> Result<T> {
     T::deserialize(self)
   }

--- a/src/v5/tests.rs
+++ b/src/v5/tests.rs
@@ -4,7 +4,7 @@ use super::serialize;
 use crate::server::PlayerUpdate;
 use crate::types::VectorExt;
 use crate::v5::{AirmashDeserializerV5, AirmashSerializerV5};
-use crate::{ServerKeyState, ServerPacket, Upgrades, Vector2};
+use crate::{GameType, ServerKeyState, ServerPacket, Upgrades, Vector2};
 
 #[test]
 fn reference_deserialize_player_update() {
@@ -91,4 +91,78 @@ fn uint24_serde() {
   assert_eq!(&serialize(0x030201), &[2, 3, 1]);
 
   assert_eq!(deserialize([2, 3, 1]), 0x030201);
+}
+
+#[test]
+fn login2_extra_invalid() {
+  #[rustfmt::skip]
+  let bytes: Vec<u8> = vec![
+    /* packet  */ crate::server::Login::V5_PACKET_NO,
+    /* success */ 1,
+    /* id      */ 1, 0,
+    /* team    */ 1, 0,
+    /* clock   */ 0, 0, 0, 0,
+    /* token   */ 0,          // empty string
+    /* ty      */ 1,          // FFA
+    /* room    */ 0,          // empty string
+    /* players */ 0, 0,       // empty array
+    /* config  */ 0, 0,       // empty string
+    /* bots    */ 32, 0,      // bad array
+  ];
+
+  let result = crate::v5::deserialize::<ServerPacket>(&bytes)
+    .expect_err("deserialization was supposed to fail");
+
+  eprintln!("{}", result);
+
+  assert_eq!(result.context(), ["id", "bots", "Login2", "ServerPacket"]);
+}
+
+#[test]
+fn login2_valid() {
+  use crate::packets::server::{Login, Login2};
+
+  #[rustfmt::skip]
+  let bytes: Vec<u8> = vec![
+    /* packet  */ crate::server::Login::V5_PACKET_NO,
+    /* success */ 1,
+    /* id      */ 1, 0,
+    /* team    */ 1, 0,
+    /* clock   */ 0, 0, 0, 0,
+    /* token   */ 0,          // empty string
+    /* ty      */ 1,          // FFA
+    /* room    */ 4, b't', b'e', b's', b't',
+    /* players */ 0, 0,       // empty array
+    /* config  */ 4, 0, b't', b'e', b's', b't',
+    /* bots    */ 1, 0,
+      /* id    */ 1, 1     
+  ];
+
+  let packet =
+    crate::v5::deserialize::<ServerPacket>(&bytes).expect("deserialization was supposed to fail");
+
+  assert!(matches!(
+    packet,
+    ServerPacket::Login2(Login2 {
+      login: Login {
+        success: true,
+        id: 1,
+        team: 1,
+        clock: 0,
+        ty: GameType::FFA,
+        ..
+      },
+      ..
+    })
+  ));
+
+  let packet = match packet {
+    ServerPacket::Login2(login2) => login2,
+    _ => unreachable!(),
+  };
+
+  assert_eq!(packet.config, "test");
+  assert_eq!(packet.room, "test");
+  assert_eq!(packet.bots.len(), 1);
+  assert_eq!(packet.bots[0].id, 0x101);
 }


### PR DESCRIPTION
The server protocol now has an extra variant and will transparently decode packets as either `Login` or `Login2` depending on whether they have extra data at the end of the `Login` packet.