### PR TITLE
Add an unknown variant to all protocol enums

### DIFF
--- a/src/custom/utils.rs
+++ b/src/custom/utils.rs
@@ -1,26 +1,20 @@
 pub(crate) mod flag_code {
-  use std::convert::TryInto;
-
   use serde::*;
 
   use crate::enums::FlagCode;
 
-  pub fn serialize<S>(flag: &FlagCode, s: S) -> Result<S::Ok, S::Error>
+  pub fn serialize<S>(&flag: &FlagCode, s: S) -> Result<S::Ok, S::Error>
   where
     S: Serializer,
   {
-    s.serialize_u32(*flag as u32)
+    s.serialize_u16(flag.into())
   }
 
   pub fn deserialize<'de, D>(de: D) -> Result<FlagCode, D::Error>
   where
     D: Deserializer<'de>,
   {
-    Ok(
-      u8::deserialize(de)?
-        .try_into()
-        .unwrap_or(FlagCode::UnitedNations),
-    )
+    Ok(u16::deserialize(de)?.into())
   }
 }
 

--- a/src/enums/flag_code.rs
+++ b/src/enums/flag_code.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::str::FromStr;
 
@@ -28,6 +29,7 @@ decl_enum! {
   /// [0]: https://doc.rust-lang.org/std/str/trait.FromStr.html
   /// [1]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
   /// [2]: #variant.UnitedNations
+  #[non_exhaustive]
   ##[default = UnitedNations]
   ##[base = u16]
   pub enum FlagCode {
@@ -312,11 +314,11 @@ impl FromStr for FlagCode {
   }
 }
 
-impl<'a> From<FlagCode> for &'a str {
-  fn from(code: FlagCode) -> &'a str {
+impl<'a> From<FlagCode> for Cow<'a, str> {
+  fn from(code: FlagCode) -> Cow<'a, str> {
     use self::FlagCode::*;
 
-    match code {
+    Cow::Borrowed(match code {
       SyrianArabRepublic => "SY",
       Thailand => "TH",
       Turkmenistan => "TM",
@@ -442,13 +444,13 @@ impl<'a> From<FlagCode> for &'a str {
       HongKong => "HK",
       CzechRepublic => "CZ",
       Bulgaria => "BG",
-    }
+      Unknown(v) => return format!("UNKNOWN({})", v).into(),
+    })
   }
 }
 
 impl From<FlagCode> for String {
   fn from(code: FlagCode) -> String {
-    let s: &'static str = code.into();
-    s.to_owned()
+    Cow::from(code).into_owned()
   }
 }

--- a/src/enums/macros.rs
+++ b/src/enums/macros.rs
@@ -1,58 +1,3 @@
-macro_rules! decl_enum_from_to {
-  {
-    $( default = $default:ident; )?
-    enum $name:ident;
-  } => {
-    decl_enum_from_to!($(default = $default, )? $name, u8,   to_u8,   from_u8);
-    decl_enum_from_to!($(default = $default, )? $name, u16,  to_u16,  from_u16);
-    decl_enum_from_to!($(default = $default, )? $name, u32,  to_u32,  from_u32);
-    decl_enum_from_to!($(default = $default, )? $name, u64,  to_u64,  from_u64);
-    decl_enum_from_to!($(default = $default, )? $name, u128, to_u128, from_u128);
-
-    decl_enum_from_to!($(default = $default, )? $name, i8,   to_i8,   from_i8);
-    decl_enum_from_to!($(default = $default, )? $name, i16,  to_i16,  from_i16);
-    decl_enum_from_to!($(default = $default, )? $name, i32,  to_i32,  from_i32);
-    decl_enum_from_to!($(default = $default, )? $name, i64,  to_i64,  from_i64);
-    decl_enum_from_to!($(default = $default, )? $name, i128, to_i128, from_i128);
-  };
-
-  (default = $default:ident, $name:ident, $ty:ident, $to:ident, $from:ident) => {
-    impl ::std::convert::From<$ty> for $name {
-      fn from(v: $ty) -> Self {
-        use ::num_traits::FromPrimitive;
-        Self::$from(v).unwrap_or(Self::default())
-      }
-    }
-
-    impl ::std::convert::From<$name> for $ty {
-      fn from(v: $name) -> Self {
-        use ::num_traits::ToPrimitive;
-        v.$to().expect("Type too large for primitive")
-      }
-    }
-  };
-  ($name:ident, $ty:ident, $to:ident, $from:ident) => {
-    impl ::std::convert::TryFrom<$ty> for $name {
-      type Error = crate::EnumValueOutOfRangeError<$ty>;
-
-      fn try_from(v: $ty) -> Result<Self, Self::Error> {
-        use ::num_traits::FromPrimitive;
-        match Self::$from(v) {
-          Some(x) => Ok(x),
-          None => Err(crate::EnumValueOutOfRangeError(v))
-        }
-      }
-    }
-
-    impl ::std::convert::From<$name> for $ty {
-      fn from(v: $name) -> Self {
-        use ::num_traits::ToPrimitive;
-        v.$to().expect("Type too large for primitive")
-      }
-    }
-  }
-}
-
 macro_rules! decl_serde_v5 {
   {
     enum $name:ident ;
@@ -89,6 +34,15 @@ macro_rules! decl_serde_v5 {
   }
 }
 
+macro_rules! enum_basetype {
+  ($basety:ty) => {
+    $basety
+  };
+  () => {
+    u8
+  };
+}
+
 macro_rules! decl_enum {
   {
     $(
@@ -110,40 +64,34 @@ macro_rules! decl_enum {
       $vis enum $name {
         $(
           $( #[$elemattr] )*
-          $elem = $value,
+          $elem,
         )*
+
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        Unknown(enum_basetype!($($basety)?))
       }
 
-      impl ::num_traits::FromPrimitive for $name {
-        fn from_u64(val: u64) -> Option<Self> {
-          Some(match val as _ {
-            $( $value => Self::$elem, )*
-            _ => return None
-          })
+      const _: () = {
+        type BaseTy = enum_basetype!($($basety)?);
+
+        impl From<BaseTy> for $name {
+          fn from(v: BaseTy) -> Self {
+            match v {
+              $( $value => Self::$elem, )*
+              v => Self::Unknown(v)
+            }
+          }
         }
 
-        fn from_i64(val: i64) -> Option<Self> {
-          Some(match val as _ {
-            $( $value => Self::$elem, )*
-            _ => return None
-          })
+        impl From<$name> for BaseTy {
+          fn from(v: $name) -> Self {
+            match v {
+              $( $name::$elem => $value, )*
+              $name::Unknown(v) => v,
+            }
+          }
         }
-      }
-
-      impl ::num_traits::ToPrimitive for $name {
-        fn to_u64(&self) -> Option<u64> {
-          Some(*self as isize as u64)
-        }
-
-        fn to_i64(&self) -> Option<i64> {
-          Some(*self as isize as i64)
-        }
-      }
-
-      decl_enum_from_to!{
-        $( default = $default; )?
-        enum $name;
-      }
+      };
 
       $(
         impl ::std::default::Default for $name {

--- a/src/enums/macros.rs
+++ b/src/enums/macros.rs
@@ -67,7 +67,6 @@ macro_rules! decl_enum {
           $elem,
         )*
 
-        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         Unknown(enum_basetype!($($basety)?))
       }
 

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -7,6 +7,7 @@ pub use self::flag_code::FlagCode;
 decl_enum! {
   /// Specifies whether the debug reply to a command should
   /// open a popup or be displayed in the chat window.
+  #[non_exhaustive]
   ##[default = ShowInPopup]
   pub enum CommandReplyType {
     ShowInConsole = 0,
@@ -21,6 +22,7 @@ decl_enum! {
   /// Details on how the mob despawned. (i.e. whether
   /// it's lifetime ended or it collided with some
   /// other object)
+  #[non_exhaustive]
   pub enum DespawnType {
     LifetimeEnded = 0,
     Collided = 1,
@@ -30,6 +32,7 @@ decl_enum! {
   ///
   /// These are all server errors that the vanilla AIRMASH
   /// client (and the current STARMASH client) understands.
+  #[non_exhaustive]
   ##[default = UnknownError]
   pub enum ErrorType {
     DisconnectedForPacketFlooding = 1,
@@ -53,22 +56,12 @@ decl_enum! {
   }
 
   /// TODO: Reverse engineer
-  ##[default = _Unknown]
-  pub enum FirewallStatus {
-    #[doc(hidden)]
-    /// Not a real value, just makes derives work
-    /// remove this once the enum is reverse engineered
-    _Unknown = 0,
-  }
+  #[non_exhaustive]
+  pub enum FirewallStatus {}
 
   /// TODO: Reverse engineer
-  ##[default = _Unknown]
-  pub enum FirewallUpdateType {
-    #[doc(hidden)]
-    /// Not a real value, just makes derives work
-    /// remove this once the enum is reverse engineered
-    _Unknown = 0,
-  }
+  #[non_exhaustive]
+  pub enum FirewallUpdateType {}
 
   /// Flag update type
   ///
@@ -82,6 +75,7 @@ decl_enum! {
   /// Implementors Note: This had a `TODO: rev-eng`
   /// comment on it but it doesn't seem to be missing
   /// any values.
+  #[non_exhaustive]
   pub enum FlagUpdateType {
     Position = 1,
     Carrier = 2,
@@ -104,6 +98,7 @@ decl_enum! {
   /// [0]: server/struct.ScoreDetailedFFA.html
   /// [1]: server/struct.ScoreDetailedCTF.html
   /// [2]: server/struct.ScoreDetailedBTR.html
+  #[non_exhaustive]
   ##[default = FFA]
   pub enum GameType {
     FFA = 1,
@@ -146,6 +141,7 @@ decl_enum! {
   ///
   /// Used by:
   /// - TODO
+  #[non_exhaustive]
   pub enum MobType {
     PredatorMissile = 1,
     GoliathMissile = 2,
@@ -163,6 +159,7 @@ decl_enum! {
   ///
   /// Used in:
   /// - TODO
+  #[non_exhaustive]
   ##[default = Predator]
   pub enum PlaneType {
     Predator = 1,
@@ -198,6 +195,7 @@ decl_enum! {
   }
 
   /// TODO: Reverse engineer
+  #[non_exhaustive]
   ##[default = Shield]
   pub enum PowerupType {
     Shield = 1,
@@ -209,6 +207,7 @@ decl_enum! {
   /// Specific identifiers for server custom messages.
   ///
   /// TODO: Reverse Engineer
+  #[non_exhaustive]
   pub enum ServerCustomType {
     /// TODO: Determine if this name is accurate
     BTRWin = 1,
@@ -219,6 +218,7 @@ decl_enum! {
   /// Type specifier for server banner messages.
   ///
   /// TODO: Reverse engineer
+  #[non_exhaustive]
   pub enum ServerMessageType {
     TimeToGameStart = 1,
     /// TODO: Verify the value of this one
@@ -232,6 +232,7 @@ decl_enum! {
   }
 
   /// All upgrade types.
+  #[non_exhaustive]
   ##[default = None]
   pub enum UpgradeType {
     /// This seems to be sent by the official server when a

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -112,6 +112,7 @@ decl_enum! {
   ///
   /// It is used in the following packets:
   /// - TODO
+  #[non_exhaustive]
   pub enum KeyCode {
     Up = 1,
     Down = 2,
@@ -128,6 +129,7 @@ decl_enum! {
   /// NOTE: The values here aren't in any way
   /// certain and should be verified before
   /// relying upon them.
+  #[non_exhaustive]
   pub enum LeaveHorizonType {
     Player = 0,
     Mob = 1,
@@ -172,6 +174,7 @@ decl_enum! {
   /// Indicate whether a player levelled up, or has
   /// just logged in and their level is being communicated
   /// to the client.
+  #[non_exhaustive]
   ##[default = Login]
   pub enum PlayerLevelType {
     Login = 0,
@@ -188,6 +191,7 @@ decl_enum! {
   /// [0]: server/struct.login.html
   /// [1]: server/struct.loginplayer.html
   /// [2]: server/struct.playernew.html
+  #[non_exhaustive]
   ##[default = Alive]
   pub enum PlayerStatus {
     Alive = 0,


### PR DESCRIPTION
I've also included `#[non_exhaustive]` on most, although not _all_ protocol enums.