### PR TITLE
Remove `smallvec` and `num-traits` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,8 @@ serde = [ "serde-feature-hack", "serde_json", "bstr/serde1" ]
 default = [ ]
 
 [dependencies]
-bstr       = { version = "0.2.16", default-features = false, features=["std"] }
-smallvec   = "1.6.1"
-num-traits = "0.2"
-mint       = "0.5"
+bstr = { version = "0.2.16", default-features = false, features=["std"] }
+mint = "0.5"
 
 [dependencies.serde_json]
 version = "1.0"


### PR DESCRIPTION
These are no longer being used so they should be dropped.