### PR TITLE
Remove `GameFirewallType`

### DIFF
--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -67,10 +67,6 @@ pub enum FirewallStatus {
 }
 
 decl_enum! {
-  /// TODO: Reverse engineer
-  #[non_exhaustive]
-  pub enum FirewallUpdateType {}
-
   /// Flag update type
   ///
   /// Used to indicate whether the flag is now being

--- a/src/packets/server.rs
+++ b/src/packets/server.rs
@@ -199,8 +199,9 @@ pub struct EventStealth {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GameFirewall {
+  /// This field is not used for anything by the client.
   #[cfg_attr(feature = "serde", serde(rename = "type"))]
-  pub ty: FirewallUpdateType,
+  pub ty: u8,
   pub status: FirewallStatus,
   #[cfg_attr(feature = "serde", serde(with = "VecRemote"))]
   pub pos: Position,


### PR DESCRIPTION
By looking at the client code we can see that `GameFirewall::type` is never actually used for anything. As such, it is easier to delete the unused (and empty) enum and instead just leave a `u8` field there.