### PR TITLE
Fix enum serialization to work as intended

### DIFF
--- a/src/enums/macros.rs
+++ b/src/enums/macros.rs
@@ -201,7 +201,7 @@ macro_rules! decl_enum {
             E: de::Error
           {
             $(
-              if value.eq_ignore_ascii_case(stringify!($elem)) {
+              if crate::util::variant_eq(value.as_bytes(), stringify!($elem)) {
                 return Ok(Self::Value::$elem);
               }
             )*
@@ -214,7 +214,7 @@ macro_rules! decl_enum {
             E: de::Error
           {
             $(
-              if value.eq_ignore_ascii_case(stringify!($elem).as_bytes()) {
+              if crate::util::variant_eq(value, stringify!($elem)) {
                 return Ok(Self::Value::$elem);
               }
             )*

--- a/src/enums/macros.rs
+++ b/src/enums/macros.rs
@@ -146,82 +146,93 @@ macro_rules! decl_enum {
 
       #[cfg(feature = "serde")]
       const _: () = {
-        use std::fmt;
-
-        use serde::de::{Unexpected, Visitor};
-        use serde::ser::SerializeTupleVariant;
-        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+        use ::serde::{Serialize, Serializer, Deserialize, Deserializer};
+        use ::serde::de::{Visitor, Unexpected, self};
+        use ::core::fmt;
 
         type BaseTy = enum_basetype!($($basety)?);
+
+        const NAME: &'static str = stringify!($name);
+        const VARIANTS: &'static [&'static str] = &[
+          $( stringify!($elem), )*
+        ];
 
         impl Serialize for $name {
           fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
           where
             S: Serializer,
           {
-            if ser.is_human_readable() {
-              enum_variant_serialize_decl! {
-                [0u32] $name => $( $elem )*;
+            if !ser.is_human_readable() {
+              return BaseTy::from(*self).serialize(ser);
+            }
 
-                match self => ser {}
-              }
-            } else {
-              BaseTy::serialize(&BaseTy::from(*self), ser)
+            match self {
+              $( Self::$elem => ser.serialize_str(stringify!($elem)), )*
+              Self::Unknown(v) => v.serialize(ser),
             }
           }
         }
 
+        struct FieldVisitor;
+        impl<'de> Visitor<'de> for FieldVisitor {
+          type Value = $name;
+
+          fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            fmt.write_str(concat!("enum ", stringify!($name)))
+          }
+
+          fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+          where
+            E: de::Error
+          {
+            use ::core::convert::TryInto;
+
+            let value: BaseTy = value.try_into() //
+              .map_err(|_| E::invalid_value(Unexpected::Unsigned(value), &self))?;
+
+            Ok(match value {
+              $( $value => Self::Value::$elem, )*
+              value => Self::Value::Unknown(value),
+            })
+          }
+
+          fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+          where
+            E: de::Error
+          {
+            $(
+              if value.eq_ignore_ascii_case(stringify!($elem)) {
+                return Ok(Self::Value::$elem);
+              }
+            )*
+
+            Err(E::unknown_variant(value, VARIANTS))
+          }
+
+          fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+          where
+            E: de::Error
+          {
+            $(
+              if value.eq_ignore_ascii_case(stringify!($elem).as_bytes()) {
+                return Ok(Self::Value::$elem);
+              }
+            )*
+
+            let value = String::from_utf8_lossy(value);
+            Err(E::unknown_variant(&value, VARIANTS))
+          }
+        }
+
         impl<'de> Deserialize<'de> for $name {
-          fn deserialize<D>(de: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+          fn deserialize<D>(de: D) -> Result<Self, D::Error>
           where
             D: Deserializer<'de>,
           {
-            struct TyVisitor;
-
-            impl<'de> Visitor<'de> for TyVisitor {
-              type Value = $name;
-
-              fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                write!(
-                  fmt,
-                  "an enum value (either a string or a {})",
-                  None
-                    $( .or_else(|| Some(stringify!($basety))) )?
-                    .unwrap_or("u8")
-                )
-              }
-
-              fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-              where
-                E: serde::de::Error,
-              {
-                match v {
-                  $( stringify!($elem) => Ok($name::$elem), )*
-                  _ => Err(E::invalid_value(Unexpected::Str(v), &self)),
-                }
-              }
-
-              fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-              where
-                E: serde::de::Error
-              {
-                use std::convert::TryFrom;
-
-                match BaseTy::try_from(v) {
-                  Ok(v) => Ok($name::from(v)),
-                  Err(_) => Err(E::invalid_value(
-                    Unexpected::Unsigned(v),
-                    &self
-                  ))
-                }
-              }
+            match de.is_human_readable() {
+              true  => de.deserialize_any(FieldVisitor),
+              false => BaseTy::deserialize(de).map(From::from),
             }
-
-            de.deserialize_enum(
-              stringify!($name),
-              &[ $( stringify!($elem) ),* ],
-              TyVisitor
-            )
           }
         }
       };

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 mod macros;
 mod flag_code;
+#[cfg(test)]
+mod tests;
 
 pub use self::flag_code::FlagCode;
 

--- a/src/enums/tests.rs
+++ b/src/enums/tests.rs
@@ -1,0 +1,48 @@
+#[cfg(feature = "serde")]
+mod serde {
+  use crate::*;
+
+  macro_rules! roundtrip_planetype_test {
+    ($test:ident => $plane:ident) => {
+      #[test]
+      fn $test() {
+        let expected = PlaneType::$plane;
+        let serialized = serde_json::to_string(&PlaneType::$plane)
+          .expect(concat!("Failed to serialize ", stringify!($plane)));
+        eprintln!("serialized = {}", serialized);
+
+        let result = serde_json::from_str(&serialized)
+          .expect(concat!("Failed to deserialize ", stringify!($plane)));
+
+        assert_eq!(expected, result, "serialized = {}", serialized);
+      }
+    };
+  }
+
+  roundtrip_planetype_test!(roundtrip_predator => Predator);
+  roundtrip_planetype_test!(roundtrip_tornado => Tornado);
+  roundtrip_planetype_test!(roundtrip_mohawk => Mohawk);
+  roundtrip_planetype_test!(roundtrip_goliath => Goliath);
+  roundtrip_planetype_test!(roundtrip_prowler => Prowler);
+
+  #[test]
+  fn planetype_deserialize_test() {
+    use self::PlaneType::*;
+
+    fn de(data: &str) -> PlaneType {
+      serde_json::from_str(data) //
+        .expect(&format!("Failed to deserialize planetype from {}", data))
+    }
+
+    // raw numerical values should work
+    assert_eq!(Predator, de("1"));
+
+    // same with all casings of the word
+    assert_eq!(Predator, de("\"Predator\""));
+    assert_eq!(Predator, de("\"predator\""));
+    assert_eq!(Predator, de("\"PrEdAtOr\""));
+
+    assert_eq!(Unknown(0), de("0"));
+    assert_eq!(Unknown(255), de("255"));
+  }
+}

--- a/src/enums/tests.rs
+++ b/src/enums/tests.rs
@@ -31,7 +31,7 @@ mod serde {
 
     fn de(data: &str) -> PlaneType {
       serde_json::from_str(data) //
-        .expect(&format!("Failed to deserialize planetype from {}", data))
+        .expect(&format!("Failed to deserialize planetype from `{}`", data))
     }
 
     // raw numerical values should work
@@ -44,5 +44,29 @@ mod serde {
 
     assert_eq!(Unknown(0), de("0"));
     assert_eq!(Unknown(255), de("255"));
+  }
+
+  #[test]
+  fn mobtype_deserialize_test() {
+    use self::MobType::*;
+
+    fn de(data: &str) -> MobType {
+      serde_json::from_str(data) //
+        .expect(&format!("Failed to deserialize mobtype from `{}`", data))
+    }
+
+    // raw numerical values should work
+    assert_eq!(PredatorMissile, de("1"));
+
+    // same with all casings
+    assert_eq!(PredatorMissile, de(r#""PredatorMissile""#));
+    assert_eq!(PredatorMissile, de(r#""PREDATORMISSILE""#));
+    assert_eq!(PredatorMissile, de(r#""predatormissile""#));
+    assert_eq!(PredatorMissile, de(r#""pReDaToRmIsSiLe""#));
+
+    // we also support kebab-case, snake_case, and SCREAMING_SNAKE_CASE
+    assert_eq!(PredatorMissile, de(r#""predator-missile""#));
+    assert_eq!(PredatorMissile, de(r#""predator_missile""#));
+    assert_eq!(PredatorMissile, de(r#""PREDATOR_MISSILE""#));
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod enums;
 mod error;
 mod packets;
 mod types;
+mod util;
 
 mod client_packet;
 mod server_packet;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,85 @@
+use bstr::ByteSlice;
+
+pub(crate) fn variant_eq(value: &[u8], variant: &str) -> bool {
+  let mut it1 = value.bytes();
+  let mut it2 = variant.bytes();
+
+  loop {
+    let (b1, b2) = match (it1.next(), it2.next()) {
+      (None, None) => return true,
+      (Some(b1), Some(b2)) => match b1 {
+        b'-' | b'_' if b2.is_ascii_uppercase() => match it1.next() {
+          Some(b1) => (b1, b2),
+          None => return false,
+        },
+        _ => (b1, b2),
+      },
+      _ => return false,
+    };
+
+    if !b1.eq_ignore_ascii_case(&b2) {
+      return false;
+    }
+  }
+}
+
+#[cfg(test)]
+mod variant_eq_tests {
+  use super::variant_eq;
+
+  macro_rules! test_variant_eq {
+    {
+      $( $name:ident => $value:literal $tt:tt $variant:literal; )*
+    } => {
+      $( test_variant_eq!($name => $value $tt $variant); )*
+    };
+    ($name:ident => $value:literal == $variant:literal) => {
+      #[test]
+      fn $name() {
+        let value: &str = $value;
+        let variant: &str = $variant;
+
+        assert!(
+          variant_eq(value.as_bytes(), variant),
+          "`{}` != `{}`",
+          value,
+          variant
+        );
+      }
+    };
+    ($name:ident => $value:literal != $variant:literal) => {
+      #[test]
+      fn $name() {
+        let value: &str = $value;
+        let variant: &str = $variant;
+
+        assert!(
+          !variant_eq(value.as_bytes(), variant),
+          "`{}` == `{}`",
+          value,
+          variant
+        );
+      }
+    };
+  }
+
+  test_variant_eq! {
+    // case-insensitivity tests
+    case_insensitive_1 => "blah" == "Blah";
+    case_insensitive_2 => "bLaH" == "Blah";
+    case_insensitive_3 => "BLEH" == "Bleh";
+    case_insensitive_4 => "bleh" == "Bleh";
+    case_insensitive_5 => "bleh" != "blah";
+
+    // kebab-case tests
+    kebab_1 => "blah-bleh-blah" == "BlahBlehBlah";
+    kebab_2 => "blahbleh-blah" == "BlahBlehBlah";
+    kebab_3 => "bl-ahBLEHblah" != "BlahBlehBlah";
+    kebab_4 => "-blahblehblah" == "BlahBlehBlah";
+
+    // SCREAMING_CASE tests
+    screaming_1 => "BLAH_BLEH" == "BlahBleh";
+    screaming_2 => "BL_AHBL_EH" != "BlahBleh";
+    screaming_3 => "BlAh_bLeH" == "BlahBleh";
+  }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,14 @@ pub(crate) fn variant_eq(value: &[u8], variant: &str) -> bool {
   let mut it1 = value.bytes();
   let mut it2 = variant.bytes();
 
+  // If the first letter is uppercase then we don't want to support adding
+  // '-' and '_' chars at the front of the string.
+  match (it1.next(), it2.next()) {
+    (None, None) => return true,
+    (Some(b1), Some(b2)) if b1.eq_ignore_ascii_case(&b2) => (),
+    _ => return false,
+  }
+
   loop {
     let (b1, b2) = match (it1.next(), it2.next()) {
       (None, None) => return true,
@@ -75,7 +83,7 @@ mod variant_eq_tests {
     kebab_1 => "blah-bleh-blah" == "BlahBlehBlah";
     kebab_2 => "blahbleh-blah" == "BlahBlehBlah";
     kebab_3 => "bl-ahBLEHblah" != "BlahBlehBlah";
-    kebab_4 => "-blahblehblah" == "BlahBlehBlah";
+    kebab_4 => "-blahblehblah" != "BlahBlehBlah";
 
     // SCREAMING_CASE tests
     screaming_1 => "BLAH_BLEH" == "BlahBleh";


### PR DESCRIPTION
This rewrites the serde serialization and deserialization implementations for all protocol enums to efficiently allow supporting unknown types and case-insensitive enum identifiers.