### PR TITLE
Clean up and format documentation

### DIFF
--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -160,9 +160,8 @@ decl_enum! {
     Prowler = 5,
   }
 
-  /// Indicate whether a player levelled up, or has
-  /// just logged in and their level is being communicated
-  /// to the client.
+  /// Indicate whether a player levelled up, or has just logged in and their
+  /// level is being communicated to the client.
   ##[default = Login]
   pub enum PlayerLevelType {
     Login = 0,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -169,8 +169,7 @@ decl_enum! {
     LevelUp = 1,
   }
 
-  /// Flag for indicating whether a player is
-  /// alive or dead.
+  /// Flag for indicating whether a player is alive or dead.
   ///
   /// This is used in the following packets:
   /// - [`Login`][0] (specifically [`LoginPlayer`][1])

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -185,18 +185,14 @@ decl_enum! {
     Dead = 1,
   }
 
-  /// TODO: Reverse engineer
+  /// The type of powerup effect that a player has.
   ##[default = Shield]
   pub enum PowerupType {
     Shield = 1,
-    /// This is just a guess.
-    /// TODO: Verify
     Inferno = 2,
   }
 
   /// Specific identifiers for server custom messages.
-  ///
-  /// TODO: Reverse Engineer
   pub enum ServerCustomType {
     /// Triggers the game-end screen in BTR.
     BTR = 1,
@@ -209,17 +205,23 @@ decl_enum! {
 
   /// Type specifier for server banner messages.
   ///
-  /// TODO: Reverse engineer
+  /// This _mostly_ doesn't correspond to behaviour within the default client.
+  /// The one exception is that [`Informational`] messages will keep showing
+  /// even if other messages are shown. However, alternate clients may use the
+  /// custom classes to show different messages in different ways.
+  ///
+  /// [`Informational`]: ServerMessageType::Informational
   pub enum ServerMessageType {
+    /// Used by the CTF server to show messages counting down to the start of
+    /// the next game.
     TimeToGameStart = 1,
-    /// TODO: Verify the value of this one
-    Flag = 2,
-    /// New Type, used by this server for shutdown message
-    /// (once they work)
-    Shutdown = 15,
-    /// New Type, used by this server for banner messages
-    /// on player join.
-    Banner = 16,
+    /// An informational message related to the current game state. This won't
+    /// be overwritten by any other message category so it should be used for
+    /// important game-related information.
+    ///
+    /// # Usage Examples
+    /// - CTF uses this server message type to show flag-related updates.
+    Informational = 2,
   }
 
   /// All upgrade types.
@@ -279,4 +281,14 @@ impl MobType {
 
     matches!(self, Shield | Inferno)
   }
+}
+
+#[allow(non_upper_case_globals)]
+impl ServerMessageType {
+  pub const Flag: Self = Self::Informational;
+  pub const Shutdown: Self = Self::Unknown(15);
+
+  /// Unofficial message type. Used by the rust server for banner messages at
+  /// login.
+  pub const Banner: Self = Self::Unknown(16);
 }

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -104,12 +104,15 @@ decl_enum! {
     BTR = 3,
   }
 
-  /// The key that's had it's state changed.
-  /// This is only used for client -> server
-  /// communication.
+  /// The key that's had it's state changed. 
+  /// 
+  /// This is only used for client to server communication. For communications
+  /// back from server to client see [`ServerKeyState`].
   ///
   /// It is used in the following packets:
   /// - TODO
+  /// 
+  /// [`ServerKeyState`]: crate::ServerKeyState
   pub enum KeyCode {
     Up = 1,
     Down = 2,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -146,8 +146,7 @@ decl_enum! {
     Inferno = 9,
   }
 
-  /// Used to indicate the type of plane
-  /// that the packet refers to.
+  /// Used to indicate the type of plane that the packet refers to.
   ///
   /// Used in:
   /// - TODO

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -176,12 +176,12 @@ decl_enum! {
   /// Flag for indicating whether a player is alive or dead.
   ///
   /// This is used in the following packets:
-  /// - [`Login`][0] (specifically [`LoginPlayer`][1])
-  /// - [`PlayerNew`][2]
+  /// - [`Login`] (specifically [`LoginPlayer`])
+  /// - [`PlayerNew`]
   ///
-  /// [0]: server/struct.login.html
-  /// [1]: server/struct.loginplayer.html
-  /// [2]: server/struct.playernew.html
+  /// [`Login`]: crate::server::Login
+  /// [`LoginPlayer`]: crate::server::LoginPlayer
+  /// [`PlayerNew`]: crate::server::PlayerNew
   ##[default = Alive]
   pub enum PlayerStatus {
     Alive = 0,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -20,11 +20,14 @@ decl_enum! {
     ShowInPopup = 1,
   }
 
-  /// Details on how the mob despawned. (i.e. whether
-  /// it's lifetime ended or it collided with some
-  /// other object)
+  /// Details on how the mob despawned. 
   pub enum DespawnType {
+    /// The mob did not hit anything and will simply vanish.
     LifetimeEnded = 0,
+    /// The mob ran into something and exploded.
+    /// 
+    /// This is generally only used for missiles, some alternate clients may
+    /// run into issues if used for box-type mobs.
     Collided = 1,
   }
 

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -30,8 +30,12 @@ decl_enum! {
 
   /// All error codes that can be sent to the client.
   ///
-  /// These are all server errors that the vanilla AIRMASH
-  /// client (and the current STARMASH client) understands.
+  /// These are all server errors that the vanilla AIRMASH client (and the
+  /// current STARMASH client) understands. [Ab-server][ab-server] has some
+  /// additional custom error types for its sync protocols but this crate
+  /// doesn't handle those packet types at the moment.
+  /// 
+  /// [ab-server]: https://github.com/wight-airmash/ab-protocol
   pub enum ErrorType {
     PacketFloodingDisconnect = 1,
     PacketFloodingBan = 2,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -82,21 +82,19 @@ decl_enum! {
 
   /// Game Type.
   ///
-  /// Hopefully self explanatory, used to indicate to
-  /// the client which game is being played. The client
-  /// uses this to decide on player colouring and
-  /// whether or not to show the flags in-game.
-  /// It will also correspond with the type of detailed
-  /// score ([`ScoreDetailedFFA`][0], [`ScoreDetailedCTF`][1],
-  /// or [`ScoreDetailedBTR`][2]) that the client expects
-  /// to receive.
+  /// This is used to indicate to the client which game type is being played.
+  /// The client will then use this to decide team colouring and whether to
+  /// show CTF flags in-game. It will also decide the type of detailed score
+  /// packet that the client expects to receive: one of [`ScoreDetailedFFA`],
+  /// [`ScoreDetailedCTF`], or [`ScoreDetailedBTR`], corresponding to `FFA`,
+  /// `CTF`, and `BTR`, respectively.
   ///
   /// Used in:
   /// - TODO
   ///
-  /// [0]: server/struct.ScoreDetailedFFA.html
-  /// [1]: server/struct.ScoreDetailedCTF.html
-  /// [2]: server/struct.ScoreDetailedBTR.html
+  /// [`ScoreDetailedFFA`]: crate::ScoreDetailedFFA
+  /// [`ScoreDetailedCTF`]: crate::ScoreDetailedCTF
+  /// [`ScoreDetailedBTR`]: crate::ScoreDetailedBTR
   ##[default = FFA]
   pub enum GameType {
     FFA = 1,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -7,16 +7,20 @@ mod tests;
 pub use self::flag_code::FlagCode;
 
 decl_enum! {
-  /// Specifies whether the debug reply to a command should
-  /// open a popup or be displayed in the chat window.
+  /// Specifies whether the debug reply to a command should open a popup or be
+  /// displayed in the chat window.
+  /// 
+  /// The original client will consider any command reply that isn't
+  /// `ShowInConsole` to be `ShowInPopup` however other clients may handle
+  /// things differently.
   ##[default = ShowInPopup]
   pub enum CommandReplyType {
+    /// Add a new message within the chat window.
     ShowInConsole = 0,
-    /// Technically this should be any value other than `0`,
-    /// the [`From`][0] integer implementation for this enum deals
-    /// with that.
-    ///
-    /// [0]: https://doc.rust-lang.org/std/convert/trait.From.html
+    /// Show a popup with the message.
+    /// 
+    /// Note that the original client will fail to show any message that is not
+    /// valid JSON if shown in a popup. 
     ShowInPopup = 1,
   }
 

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -128,9 +128,8 @@ decl_enum! {
 
   /// Types of all mobs present in the game.
   ///
-  /// In AIRMASH, mobs are any non-player and non-wall
-  /// items that can be interacted with. This includes
-  /// powerups, upgrades, and all missiles.
+  /// In AIRMASH, mobs are any non-player and non-wall items that can be
+  /// interacted with. This includes powerups, upgrades, and all missiles.
   ///
   /// Used by:
   /// - TODO

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -65,16 +65,11 @@ decl_enum! {
 
   /// Flag update type
   ///
-  /// Used to indicate whether the flag is now being
-  /// carried by a player or whether the update
-  /// sets the position of the flag directly.
+  /// Used to indicate whether the flag is now being carried by a player or
+  /// whether the update sets the position of the flag directly.
   ///
   /// Used in:
   /// - TODO
-  ///
-  /// Implementors Note: This had a `TODO: rev-eng`
-  /// comment on it but it doesn't seem to be missing
-  /// any values.
   pub enum FlagUpdateType {
     Position = 1,
     Carrier = 2,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -227,10 +227,9 @@ decl_enum! {
   /// All upgrade types.
   ##[default = None]
   pub enum UpgradeType {
-    /// This seems to be sent by the official server when a
-    /// player leaves. Packets with this value are ignored
-    /// by the client, so they don't seem to affect gameplay
-    /// at all.
+    /// This seems to be sent by the official server when a player leaves.
+    /// Packets with this value are ignored by the client, so they don't seem
+    /// to affect gameplay at all.
     None = 0,
     Speed = 1,
     Defense = 2,

--- a/src/enums/mod.rs
+++ b/src/enums/mod.rs
@@ -9,7 +9,7 @@ pub use self::flag_code::FlagCode;
 decl_enum! {
   /// Specifies whether the debug reply to a command should open a popup or be
   /// displayed in the chat window.
-  /// 
+  ///
   /// The original client will consider any command reply that isn't
   /// `ShowInConsole` to be `ShowInPopup` however other clients may handle
   /// things differently.
@@ -18,18 +18,18 @@ decl_enum! {
     /// Add a new message within the chat window.
     ShowInConsole = 0,
     /// Show a popup with the message.
-    /// 
+    ///
     /// Note that the original client will fail to show any message that is not
-    /// valid JSON if shown in a popup. 
+    /// valid JSON if shown in a popup.
     ShowInPopup = 1,
   }
 
-  /// Details on how the mob despawned. 
+  /// Details on how the mob despawned.
   pub enum DespawnType {
     /// The mob did not hit anything and will simply vanish.
     LifetimeEnded = 0,
     /// The mob ran into something and exploded.
-    /// 
+    ///
     /// This is generally only used for missiles, some alternate clients may
     /// run into issues if used for box-type mobs.
     Collided = 1,
@@ -41,7 +41,7 @@ decl_enum! {
   /// current STARMASH client) understands. [Ab-server][ab-server] has some
   /// additional custom error types for its sync protocols but this crate
   /// doesn't handle those packet types at the moment.
-  /// 
+  ///
   /// [ab-server]: https://github.com/wight-airmash/ab-protocol
   pub enum ErrorType {
     PacketFloodingDisconnect = 1,
@@ -108,14 +108,14 @@ decl_enum! {
     BTR = 3,
   }
 
-  /// The key that's had it's state changed. 
-  /// 
+  /// The key that's had it's state changed.
+  ///
   /// This is only used for client to server communication. For communications
   /// back from server to client see [`ServerKeyState`].
   ///
   /// It is used in the following packets:
   /// - TODO
-  /// 
+  ///
   /// [`ServerKeyState`]: crate::ServerKeyState
   pub enum KeyCode {
     Up = 1,

--- a/src/packets/server.rs
+++ b/src/packets/server.rs
@@ -350,7 +350,8 @@ pub struct MobUpdate {
   pub max_speed: Speed,
 }
 
-/// MobUpdate but extended with an extra ownerId field as present in ab-protocol.
+/// MobUpdate but extended with an extra ownerId field as present in
+/// ab-protocol.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MobUpdate2 {
@@ -374,9 +375,11 @@ pub struct PingResult {
 
 /// A ping request by the server.
 ///
-/// All clients must respond with a [`Pong`](../client/struct.pong.html) with
-/// `num` set to the same value as this packet. If a client does not do this,
-/// the client will be disconnected by the server.
+/// All clients must respond with a [`Pong`] with `num` set to the same value as
+/// this packet. If a client does not do this, the client will be disconnected
+/// by the server.
+///
+/// [`Pong`]: crate::client::Pong
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ping {

--- a/src/packets/server.rs
+++ b/src/packets/server.rs
@@ -350,7 +350,7 @@ pub struct MobUpdate {
   pub max_speed: Speed,
 }
 
-/// MobUpdate but extended with an extra ownerId field as present ab-protocol.
+/// MobUpdate but extended with an extra ownerId field as present in ab-protocol.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MobUpdate2 {

--- a/src/packets/server.rs
+++ b/src/packets/server.rs
@@ -317,7 +317,9 @@ pub struct MobDespawn {
   pub ty: DespawnType,
 }
 
-/// Update for powerups
+/// Update for an immobile mob.
+///
+/// This is sent when a powerup is enters a player's view radius.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MobUpdateStationary {
@@ -328,6 +330,10 @@ pub struct MobUpdateStationary {
   pub pos: Position,
 }
 
+/// Update for a mobile missile-type mob.
+///
+/// This is sent when a mob enters a player's view radius or something changes
+/// about its state that needs to be communicated to the client.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MobUpdate {
@@ -453,8 +459,10 @@ pub struct PlayerLeave {
   pub id: Player,
 }
 
-/// Assign a level to a player. Either the player levelled up, or the server is
-/// updating their level for all clients.
+/// Assign a level to a player.
+///
+/// Either the player levelled up, or the server is updating their level for all
+/// clients.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PlayerLevel {


### PR DESCRIPTION
Many of the protocol enums had sparse and badly formatted documentation. This PR cleans that up and rewrites some of the worse or missing documentation to be more accurate.